### PR TITLE
Fix: corrected bug in account-pin creation component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -100,5 +100,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/components/account-pin/account-pin.component.html
+++ b/src/app/components/account-pin/account-pin.component.html
@@ -7,14 +7,15 @@
       <!-- "Generate PIN" form -->
       <h2 class="text-3xl font-semibold mb-6 text-center">Generate PIN</h2>
       <form
+        *ngIf="pinChangeForm"
         [formGroup]="pinChangeForm"
         (ngSubmit)="onSubmitGeneratePIN()"
         class="space-y-4"
       >
         <div>
-          <label for="newPinGenerate" class="block text-sm font-bold mb-2"
-            >New PIN:</label
-          >
+          <label for="newPinGenerate" class="block text-sm font-bold mb-2">
+            New PIN:
+          </label>
           <input
             formControlName="newPin"
             type="password"
@@ -32,10 +33,11 @@
             New PIN is required and must be 4 digits.
           </div>
         </div>
+
         <div>
-          <label for="confirmPinGenerate" class="block text-sm font-bold mb-2"
-            >Confirm PIN:</label
-          >
+          <label for="confirmPinGenerate" class="block text-sm font-bold mb-2">
+            Confirm PIN:
+          </label>
           <input
             formControlName="confirmPin"
             type="password"
@@ -58,10 +60,11 @@
             </div>
           </div>
         </div>
+
         <div>
-          <label for="passwordGenerate" class="block text-sm font-bold mb-2"
-            >Password:</label
-          >
+          <label for="passwordGenerate" class="block text-sm font-bold mb-2">
+            Password:
+          </label>
           <input
             formControlName="password"
             type="password"
@@ -79,6 +82,7 @@
             Password is required.
           </div>
         </div>
+
         <div class="flex justify-center">
           <button
             type="submit"
@@ -95,14 +99,15 @@
       <!-- "Change PIN" form -->
       <h2 class="text-3xl font-semibold mb-6 text-center">Change PIN</h2>
       <form
+        *ngIf="pinChangeForm"
         [formGroup]="pinChangeForm"
         (ngSubmit)="onSubmitChangePIN()"
         class="space-y-4"
       >
         <div>
-          <label for="oldPin" class="block text-sm font-bold mb-2"
-            >Old PIN:</label
-          >
+          <label for="oldPin" class="block text-sm font-bold mb-2">
+            Old PIN:
+          </label>
           <input
             formControlName="oldPin"
             type="password"
@@ -120,10 +125,11 @@
             Old PIN is required and must be 4 digits.
           </div>
         </div>
+
         <div>
-          <label for="newPinChange" class="block text-sm font-bold mb-2"
-            >New PIN:</label
-          >
+          <label for="newPinChange" class="block text-sm font-bold mb-2">
+            New PIN:
+          </label>
           <input
             formControlName="newPin"
             type="password"
@@ -141,10 +147,11 @@
             New PIN is required and must be 4 digits.
           </div>
         </div>
+
         <div>
-          <label for="passwordChange" class="block text-sm font-bold mb-2"
-            >Password:</label
-          >
+          <label for="passwordChange" class="block text-sm font-bold mb-2">
+            Password:
+          </label>
           <input
             formControlName="password"
             type="password"
@@ -162,6 +169,7 @@
             Password is required.
           </div>
         </div>
+
         <div class="flex justify-center">
           <button
             type="submit"
@@ -175,6 +183,7 @@
     </ng-template>
   </div>
 </div>
+
 <ng-template #loader>
   <div class="flex items-center justify-center h-full">
     <div class="loader">Loading</div>


### PR DESCRIPTION
Problem:
1. The AccountPinComponent template attempted to bind [formGroup]="pinChangeForm" before the form was initialized.

2. Since pinChangeForm was created only after the async checkPinCreated() API call, Angular rendered the template with undefined, causing:
NG01052: formGroup expects a FormGroup instance
TypeError: cannot read properties of undefined (reading 'get')

Fix:
1. HTML: Wrapped <form> elements with *ngIf="pinChangeForm" so they only render once the form exists.

2. TypeScript: Pre‑initialized pinChangeForm with a safe default FormGroup in ngOnInit to ensure it’s never undefined, then re‑initialized it properly after the API response.

3. Added fallback handling for plain‑text API responses (e.g., "PIN has not been created...") to correctly toggle between Generate PIN and Change PIN forms.